### PR TITLE
Updating broken link for cipher list

### DIFF
--- a/security.md
+++ b/security.md
@@ -156,7 +156,7 @@ set up [WireGuard](https://www.wireguard.com/) for yourself -- it's
 [excellent](https://latacora.singles/2018/05/16/there-will-be.html)!
 
 There are also secure configuration settings for a lot of
-internet-enabled applications at [cipherli.st](https://cipherli.st/). If
+internet-enabled applications at [cipherlist.eu](https://cipherlist.eu/). If
 you're particularly privacy-oriented,
 [privacytools.io](https://privacytools.io) is also a good resource.
 


### PR DESCRIPTION
The link to cipherli.st was broken, updating to working link at cipherlist.eu